### PR TITLE
Allow disabling the upload of images taken from the device

### DIFF
--- a/lib/src/widgets/toolbar_widget.dart
+++ b/lib/src/widgets/toolbar_widget.dart
@@ -2038,8 +2038,10 @@ class ToolbarWidgetState extends State<ToolbarWidget> {
                                   if (filename.text.isEmpty &&
                                       url.text.isEmpty) {
                                     setState(() {
-                                      validateFailed =
-                                          'Please either choose an image or enter an image URL!';
+                                      validateFailed = widget.htmlToolbarOptions
+                                              .allowImagePicking
+                                          ? 'Please either choose an image or enter an image URL!'
+                                          : 'Please enter an image URL!';
                                     });
                                   } else if (filename.text.isNotEmpty &&
                                       url.text.isNotEmpty) {

--- a/lib/src/widgets/toolbar_widget.dart
+++ b/lib/src/widgets/toolbar_widget.dart
@@ -1943,64 +1943,77 @@ class ToolbarWidgetState extends State<ToolbarWidget> {
                                 mainAxisSize: MainAxisSize.min,
                                 crossAxisAlignment: CrossAxisAlignment.start,
                                 children: [
-                                  Text('Select from files',
-                                      style: TextStyle(
-                                          fontWeight: FontWeight.bold)),
-                                  SizedBox(height: 10),
-                                  TextFormField(
-                                      controller: filename,
-                                      readOnly: true,
-                                      decoration: InputDecoration(
-                                        prefixIcon: ElevatedButton(
-                                          style: ElevatedButton.styleFrom(
-                                              backgroundColor: Theme.of(context)
-                                                  .dialogBackgroundColor,
-                                              padding: EdgeInsets.only(
-                                                  left: 5, right: 5),
-                                              elevation: 0.0),
-                                          onPressed: () async {
-                                            result = await FilePicker.platform
-                                                .pickFiles(
-                                              type: FileType.image,
-                                              withData: true,
-                                              allowedExtensions: widget
-                                                  .htmlToolbarOptions
-                                                  .imageExtensions,
-                                            );
-                                            if (result?.files.single.name !=
-                                                null) {
-                                              setState(() {
-                                                filename.text =
-                                                    result!.files.single.name;
-                                              });
-                                            }
-                                          },
-                                          child: Text('Choose image',
-                                              style: TextStyle(
-                                                  color: Theme.of(context)
-                                                      .textTheme
-                                                      .bodyText1
-                                                      ?.color)),
-                                        ),
-                                        suffixIcon: result != null
-                                            ? IconButton(
-                                                icon: Icon(Icons.close),
-                                                onPressed: () {
-                                                  setState(() {
-                                                    result = null;
-                                                    filename.text = '';
-                                                  });
-                                                })
-                                            : Container(height: 0, width: 0),
-                                        errorText: validateFailed,
-                                        errorMaxLines: 2,
-                                        border: InputBorder.none,
-                                      )),
-                                  SizedBox(height: 20),
-                                  Text('URL',
-                                      style: TextStyle(
-                                          fontWeight: FontWeight.bold)),
-                                  SizedBox(height: 10),
+                                  if (widget
+                                      .htmlToolbarOptions.allowImagePicking)
+                                    Text('Select from files',
+                                        style: TextStyle(
+                                            fontWeight: FontWeight.bold)),
+                                  if (widget
+                                      .htmlToolbarOptions.allowImagePicking)
+                                    SizedBox(height: 10),
+                                  if (widget
+                                      .htmlToolbarOptions.allowImagePicking)
+                                    TextFormField(
+                                        controller: filename,
+                                        readOnly: true,
+                                        decoration: InputDecoration(
+                                          prefixIcon: ElevatedButton(
+                                            style: ElevatedButton.styleFrom(
+                                                backgroundColor:
+                                                    Theme.of(context)
+                                                        .dialogBackgroundColor,
+                                                padding: EdgeInsets.only(
+                                                    left: 5, right: 5),
+                                                elevation: 0.0),
+                                            onPressed: () async {
+                                              result = await FilePicker.platform
+                                                  .pickFiles(
+                                                type: FileType.image,
+                                                withData: true,
+                                                allowedExtensions: widget
+                                                    .htmlToolbarOptions
+                                                    .imageExtensions,
+                                              );
+                                              if (result?.files.single.name !=
+                                                  null) {
+                                                setState(() {
+                                                  filename.text =
+                                                      result!.files.single.name;
+                                                });
+                                              }
+                                            },
+                                            child: Text('Choose image',
+                                                style: TextStyle(
+                                                    color: Theme.of(context)
+                                                        .textTheme
+                                                        .bodyText1
+                                                        ?.color)),
+                                          ),
+                                          suffixIcon: result != null
+                                              ? IconButton(
+                                                  icon: Icon(Icons.close),
+                                                  onPressed: () {
+                                                    setState(() {
+                                                      result = null;
+                                                      filename.text = '';
+                                                    });
+                                                  })
+                                              : Container(height: 0, width: 0),
+                                          errorText: validateFailed,
+                                          errorMaxLines: 2,
+                                          border: InputBorder.none,
+                                        )),
+                                  if (widget
+                                      .htmlToolbarOptions.allowImagePicking)
+                                    SizedBox(height: 20),
+                                  if (widget
+                                      .htmlToolbarOptions.allowImagePicking)
+                                    Text('URL',
+                                        style: TextStyle(
+                                            fontWeight: FontWeight.bold)),
+                                  if (widget
+                                      .htmlToolbarOptions.allowImagePicking)
+                                    SizedBox(height: 10),
                                   TextField(
                                     controller: url,
                                     focusNode: urlFocus,

--- a/lib/utils/options.dart
+++ b/lib/utils/options.dart
@@ -405,8 +405,8 @@ class HtmlToolbarOptions {
   final BorderRadius? buttonBorderRadius;
   final double? buttonBorderWidth;
 
-  /// Allow the user to choose an image from their device when
-  /// image selection is enabled.
+  /// Allow the user to choose an image from their device when image selection
+  /// is enabled. Inserting images via URL will still be possible if this is false.
   final bool allowImagePicking;
 }
 

--- a/lib/utils/options.dart
+++ b/lib/utils/options.dart
@@ -189,6 +189,7 @@ class HtmlToolbarOptions {
     this.toolbarItemHeight = 36,
     this.gridViewHorizontalSpacing = 5,
     this.gridViewVerticalSpacing = 5,
+    this.allowImagePicking = true,
   });
 
   /// Allows you to set the allowed extensions when a user inserts an audio file
@@ -403,6 +404,10 @@ class HtmlToolbarOptions {
   final Color? buttonSelectedBorderColor;
   final BorderRadius? buttonBorderRadius;
   final double? buttonBorderWidth;
+
+  /// Allow the user to choose an image from their device when
+  /// image selection is enabled.
+  final bool allowImagePicking;
 }
 
 /// Other options such as the height of the widget and the decoration surrounding it


### PR DESCRIPTION
Use-case : I will not handle file upload in the app, but the user should still be allowed to use external sources to host his images.

I did it with as few changes possible, let me know if you'd rather it be handled in another way.