### PR TITLE
Downgrade `pointer_interceptor` to version `v0.9.1` to avoid crash when render multi html editor

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -26,8 +26,9 @@ dependencies:
   numberpicker: ^2.1.1
   # plugin to allow dropdowns and dialogs to be interactable when displaying over the editor
   # related to https://github.com/flutter/flutter/issues/54027
+  # Related to https://github.com/flutter/flutter/issues/118159
   # pinned to 0.9.1 because of issues with CanvasKit in the latest versions
-  pointer_interceptor: ^0.9.3+3
+  pointer_interceptor: 0.9.1
   # plugin to help maintain effective Dart standards
   pedantic: ^1.11.1
   # plugin for @internal annotation


### PR DESCRIPTION
### Issue

- https://github.com/tneotia/html-editor-enhanced/issues/394

### Workaround

- Downgrade `pointer_interceptor` to version `v0.9.1`