### PR TITLE
feat: Remove iOS accessory bar 

### DIFF
--- a/lib/src/widgets/html_editor_widget_mobile.dart
+++ b/lib/src/widgets/html_editor_widget_mobile.dart
@@ -150,6 +150,7 @@ class _HtmlEditorWidgetMobileState extends State<HtmlEditorWidget> {
                     useHybridComposition: widget.htmlEditorOptions
                         .androidUseHybridComposition,
                     loadWithOverviewMode: true,
+                    disableInputAccessoryView: true,
                   ),
                   initialUserScripts:
                       widget.htmlEditorOptions.mobileInitialScripts


### PR DESCRIPTION
The accessory bar is always displayed on iOS but serves no purpose.
![image](https://github.com/user-attachments/assets/bf94a3f1-6b58-44d9-8aac-6b3418868335)

It can be removed by setting the `InAppWebViewSettings.disableInputAccessoryView` to `true`

Should I make it a parameter of `HtmlEditorOptions` (with a default value to true) ? 