### PR TITLE
fix: Undefined name 'platformViewRegistry'.

### DIFF
--- a/lib/utils/shims/dart_ui_real.dart
+++ b/lib/utils/shims/dart_ui_real.dart
@@ -2,4 +2,4 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-export 'dart:ui';
+export 'dart:ui_web';


### PR DESCRIPTION
The ui.platformViewRegistry (currently deprecated) will be removed on the next flutter stable release.

Which throws:
Error: Undefined name 'platformViewRegistry'.

The solution is to use dart:ui_web instead of dart:ui, both available in flutter.